### PR TITLE
Hotfix k8s no service endpoints

### DIFF
--- a/deployments/kubernetes/performance/grafana/deployment/testing/deployment.yml
+++ b/deployments/kubernetes/performance/grafana/deployment/testing/deployment.yml
@@ -6,7 +6,7 @@ metadata:
   namespace: grafana
   labels:
     app: grafana
-    env: test
+    env: testing
 spec:
   replicas: 1
   strategy:
@@ -14,13 +14,15 @@ spec:
   selector:
     matchLabels:
       app: grafana
-      env: test
+      env: testing
   template:
     metadata:
       labels:
         app: grafana
-        env: test
+        env: testing
     spec:
+      nodeSelector:
+        env: testing
       containers:
         - name: grafana
           image: "{{ grafana_container_image }}"

--- a/deployments/kubernetes/performance/grafana/service.yml
+++ b/deployments/kubernetes/performance/grafana/service.yml
@@ -11,7 +11,7 @@ spec:
   ports:
   - protocol: TCP
     port: 3000
-    targetPort: http
+    targetPort: 3000
     nodePort: 32000
   #TODO nodeport information is missing in our deployment view 
   externalTrafficPolicy: Cluster

--- a/deployments/kubernetes/performance/performance-storage-service/deployment/testing/deployment.yml
+++ b/deployments/kubernetes/performance/performance-storage-service/deployment/testing/deployment.yml
@@ -6,7 +6,7 @@ metadata:
   namespace: performance
   labels:
     app: pss
-    env: test
+    env: testing
 spec:
   replicas: 1
   strategy:
@@ -14,13 +14,15 @@ spec:
   selector:
     matchLabels:
       app: pss
-      env: test
+      env: testing
   template:
     metadata:
       labels:
         app: pss
-        env: test
+        env: testing
     spec:
+      nodeSelector:
+        env: testing
       containers:
         - name: performance-storage-service
           image: "{{ pss_container_image }}"

--- a/deployments/kubernetes/performance/performance-storage-service/service.yml
+++ b/deployments/kubernetes/performance/performance-storage-service/service.yml
@@ -11,6 +11,6 @@ spec:
   ports:
   - protocol: TCP
     port: 8080
-    targetPort: http
+    targetPort: 8080
     nodePort: 31000
   #externalTrafficPolicy: Cluster


### PR DESCRIPTION
for both the `performance-storage-service` and the `grafana`
- solved `nodeSelector` issue to enforce deployment on specific env node
- solved the service no endpoint issue by correcting the `targetPort`